### PR TITLE
Flatpak パッケージングの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 /CMakeCache.txt
 
 /compile_commands.json
+# Flatpak ビルド成果物
+.flatpak-builder/
+packaging/flatpak/build-dir/
+packaging/flatpak/hazkey-repo/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Hazkey input method for fcitx5
 
 [インストールガイド](https://hazkey.hiira.dev/docs/install)
 
-現在AURと[debianパッケージ](https://github.com/7ka-Hiira/fcitx5-hazkey/releases/latest)が利用できます。
+AURと[debianパッケージ](https://github.com/7ka-Hiira/fcitx5-hazkey/releases/latest)と[Flatpak のローカルビルド](./packaging/flatpak/README.md)が利用できます。
 
 ## ビルド
 

--- a/fcitx5-hazkey/CMakeLists.txt
+++ b/fcitx5-hazkey/CMakeLists.txt
@@ -27,9 +27,13 @@ fcitx5_add_i18n_definition()
 find_package(Gettext REQUIRED)
 
 if(HAZKEY_FLATPAK)
-    set(HAZKEY_ICON_NAME "org.hazkey.Fcitx5.Addon.Hazkey")
+    set(HAZKEY_ICON_NAME "org.fcitx.Fcitx5.Addon.Hazkey")
+    # Flatpak sandbox の PATH に拡張の bin/ が含まれないためフルパスで指定。
+    # このパスはマニフェストの prefix (/app/addons/Hazkey) と一致させる必要がある。
+    set(HAZKEY_SETTINGS_COMMAND "/app/addons/Hazkey/bin/hazkey-settings")
 else()
     set(HAZKEY_ICON_NAME "hazkey")
+    set(HAZKEY_SETTINGS_COMMAND "hazkey-settings")
 endif()
 
 add_subdirectory(po)

--- a/fcitx5-hazkey/src/hazkey_config.h
+++ b/fcitx5-hazkey/src/hazkey_config.h
@@ -21,6 +21,6 @@ FCITX_CONFIGURATION(HazkeyEngineConfig,
                         _("Show [Press Tab to Select] indicator"), true};
                     ExternalOption openHazkeySettings{
                         this, "openHazkeySettings", _("Open Hazkey Settings"),
-                        stringutils::concat("hazkey-settings")};);
+                        stringutils::concat(HAZKEY_SETTINGS_COMMAND)};);
 }  // namespace fcitx
 #endif  // _FCITX5_HAZKEY_HAZKEY_CONFIG_H_

--- a/fcitx5-hazkey/src/hazkey_constants.h.in
+++ b/fcitx5-hazkey/src/hazkey_constants.h.in
@@ -4,5 +4,6 @@
 #include <string>
 
 const std::string HAZKEY_VERSION = "@PROJECT_VERSION@";
+const std::string HAZKEY_SETTINGS_COMMAND = "@HAZKEY_SETTINGS_COMMAND@";
 
 #endif

--- a/hazkey-server/CMakeLists.txt
+++ b/hazkey-server/CMakeLists.txt
@@ -159,11 +159,12 @@ endif()
 
 # install icons
 if(HAZKEY_FLATPAK)
-    set(HAZKEY_ICON_NAME "org.hazkey.Fcitx5.Addon.Hazkey")
+    set(HAZKEY_ICON_NAME "org.fcitx.Fcitx5.Addon.Hazkey")
 else()
     set(HAZKEY_ICON_NAME "hazkey")
 endif()
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/icons/hazkey.svg
+        RENAME ${HAZKEY_ICON_NAME}.svg
         DESTINATION ${CMAKE_INSTALL_FULL_DATADIR}/icons/hicolor/scalable/apps)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/icons/hazkey_256x256.png
         RENAME ${HAZKEY_ICON_NAME}.png

--- a/hazkey-settings/CMakeLists.txt
+++ b/hazkey-settings/CMakeLists.txt
@@ -22,6 +22,14 @@ find_package(Protobuf REQUIRED)
 
 set(TS_FILES hazkey-settings_ja_JP.ts)
 
+if(HAZKEY_FLATPAK)
+    set(HAZKEY_ICON_NAME "org.fcitx.Fcitx5.Addon.Hazkey")
+    set(HAZKEY_SETTINGS_DESKTOP_FILE_NAME org.fcitx.Fcitx5.Addon.Hazkey.hazkey-settings)
+else()
+    set(HAZKEY_ICON_NAME "hazkey")
+    set(HAZKEY_SETTINGS_DESKTOP_FILE_NAME hazkey-settings)
+endif()
+
 configure_file(constants.h.in constants.h @ONLY)
 
 # Proto files
@@ -138,14 +146,6 @@ install(TARGETS hazkey-settings
 )
 
 # install desktop entry
-if(HAZKEY_FLATPAK)
-    set(HAZKEY_ICON_NAME "org.hazkey.Fcitx5.Addon.Hazkey")
-    set(HAZKEY_SETTINGS_DESKTOP_FILE_NAME org.hazkey.Fcitx5.Addon.Hazkey.hazkey-settings)
-else()
-    set(HAZKEY_ICON_NAME "hazkey")
-    set(HAZKEY_SETTINGS_DESKTOP_FILE_NAME hazkey-settings)
-endif()
-
 configure_file(hazkey-settings.desktop.in ${HAZKEY_SETTINGS_DESKTOP_FILE_NAME}.desktop @ONLY)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${HAZKEY_SETTINGS_DESKTOP_FILE_NAME}.desktop"
     DESTINATION ${CMAKE_INSTALL_FULL_DATADIR}/applications)

--- a/hazkey-settings/constants.h.in
+++ b/hazkey-settings/constants.h.in
@@ -2,5 +2,6 @@
 #define CONSTANTS_H
 
 inline constexpr char HAZKEY_VERSION_STR[] = "@PROJECT_VERSION@";
+inline constexpr char HAZKEY_SETTINGS_DESKTOP_FILE_NAME[] = "@HAZKEY_SETTINGS_DESKTOP_FILE_NAME@";
 
 #endif

--- a/hazkey-settings/main.cpp
+++ b/hazkey-settings/main.cpp
@@ -3,10 +3,12 @@
 #include <QLocale>
 #include <QTranslator>
 
+#include "constants.h"
 #include "mainwindow.h"
 
 int main(int argc, char* argv[]) {
     QApplication a(argc, argv);
+    a.setDesktopFileName(HAZKEY_SETTINGS_DESKTOP_FILE_NAME);
 
     // Load Qt base translations for standard widgets (e.g., file dialogs)
     QTranslator qtTranslator;

--- a/packaging/flatpak/.gitignore
+++ b/packaging/flatpak/.gitignore
@@ -1,0 +1,2 @@
+# install.sh --local で生成されるクリーンコピー
+local-src/

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -1,0 +1,132 @@
+# Flatpak
+
+Hazkey を Flatpak の Fcitx5 の拡張アドオンとしてパッケージします。
+
+プラグイン (fcitx5-hazkey)、変換エンジン (hazkey-server)、設定GUI (hazkey-settings) の
+3コンポーネントすべてが 1 つの Fcitx5 拡張に含まれます。
+
+## インストール
+
+### 前提条件
+
+- `flatpak`、`flatpak-builder`、`appstreamcli` がインストールされていること
+- Flathub リポジトリが追加されていること
+
+```sh
+flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+```
+
+### 実行
+
+`install.sh` がランタイムの取得、ビルド、ローカルリポジトリの作成、インストールを
+すべて自動で行います。
+
+```sh
+packaging/flatpak/install.sh
+```
+
+ローカルにチェックアウトしたソースからビルドする場合は `--local` を指定します。
+
+```sh
+packaging/flatpak/install.sh --local
+```
+
+インストール後、Fcitx5 を再起動すると Hazkey が利用可能になります。
+
+## アンインストール
+
+`uninstall.sh` で Flatpak 拡張、ローカルリモート、ビルド成果物、
+デスクトップエントリをすべて削除します。
+
+```sh
+packaging/flatpak/uninstall.sh
+```
+
+## 手動でのビルド・インストール
+
+スクリプトを使わずに手動で行う場合：
+
+```sh
+# ランタイムのインストール
+flatpak install --user flathub org.fcitx.Fcitx5//stable
+flatpak install --user flathub org.kde.Sdk//6.9
+
+# ビルドし、結果を packaging/flatpak/hazkey-repo/ にエクスポート
+flatpak-builder --user --force-clean --repo=packaging/flatpak/hazkey-repo packaging/flatpak/build-dir packaging/flatpak/org.fcitx.Fcitx5.Addon.Hazkey.yml
+
+# packaging/flatpak/hazkey-repo/ を "hazkey-local" という名前で Flatpak リモートとして登録
+flatpak remote-add --user --no-gpg-verify hazkey-local packaging/flatpak/hazkey-repo
+
+# 登録したリモートからインストール
+flatpak install --user hazkey-local org.fcitx.Fcitx5.Addon.Hazkey
+```
+
+## メンテナー向けノート
+
+### Flathub への公開について
+
+現時点では Flathub への公開はできません。以下の課題を解決する必要があります。
+
+#### 1. ビルド時のネットワークアクセス (`--share=network`)
+
+Flathub ではビルド中のネットワークアクセスが禁止されています
+([要件](https://docs.flathub.org/docs/for-app-authors/requirements),
+[flathub/flathub#3392](https://github.com/flathub/flathub/issues/3392))。
+現在のマニフェストでは SwiftPM の依存関係取得のために `--share=network` を使用しています。
+
+Flathub に公開するには、SwiftPM の依存関係を事前にダウンロードし、
+オフラインでビルドできるようにする必要があります。
+解決策:
+[flatpak-spm-generator](https://github.com/flatpak/flatpak-builder-tools/tree/master/spm) を使うことで SwiftPM の依存関係を
+flatpak-builder の sources として生成できます。ただし SwiftPM の内部フォーマット
+(`workspace-state.json`) に依存しているため、Swift バージョン更新時に動作確認が必要です。
+
+- [ ] ネットワークアクセスの解消
+  - flatpak-spm-generator の検証
+  - `--share=network` の除去
+  - (任意) CI での差分チェック
+
+#### 2. KDE SDK のバージョン固定
+
+Swift の C++ interop が GCC 15 のヘッダーと互換性がないため
+([swiftlang/swift#81774](https://github.com/swiftlang/swift/issues/81774))、
+KDE SDK 6.9 (freedesktop SDK 24.08, GCC 14) に固定しています。
+Flathub は通常最新の SDK を要求するため、Swift 側の修正が入るまでブロッカーになります。
+
+> [!NOTE]
+> 修正 PR ([#87620](https://github.com/swiftlang/swift/pull/87620)) は 2026-03-03 に main にマージ済みですが、
+> リリース版 (6.2.4 時点) にはまだ含まれていません。cherry-pick を待つ必要があります。
+
+#### 3. 拡張のデスクトップエントリ・アイコンのエクスポート
+
+Flatpak は拡張のデスクトップエントリとアイコンをホスト側にエクスポートしません
+(アイコン: [flatpak/flatpak#4006](https://github.com/flatpak/flatpak/issues/4006),
+デスクトップエントリ: [flatpak/flatpak#5888](https://github.com/flatpak/flatpak/issues/5888))。
+ローカルビルドでは `install.sh` が手動コピーで対処しています。
+
+hazkey-settings はランチャーから起動できず、アイコンもトレイに表示されません。
+Fcitx5 の設定UIからは起動できるため、デスクトップエントリはブロッカーではなく利便性の問題です。
+
+解決策案:
+
+- Flatpak 本体の upstream 対応を待つ (上記 issue、いずれも進展なし)
+- hazkey-settings を独立した Flatpak アプリとしてパッケージする
+- Fcitx5 本体のマニフェストにエントリ・アイコンを含める
+  (Mozc アイコンと同様。[fcitx/flatpak-fcitx5](https://github.com/fcitx/flatpak-fcitx5) への変更が必要)
+
+### その他の TODO
+
+- [ ] Flatpak リポジトリをセルフホストする
+  - OSTree リポジトリをビルドし、`flatpak remote-add` で追加できる公開リポジトリを提供する
+  - GitHub Pages + GitHub Actions など
+  - 上記問題 3 の解決が必要
+- [ ] [fcitx/flatpak-fcitx5](https://github.com/fcitx/flatpak-fcitx5) にこのマニフェストを追加する
+- [ ] 上記問題 1 ~ 3 の課題がすべて解決したら Flathub で公開する
+  - <https://docs.flathub.org/docs/for-app-authors/requirements>
+
+### マニフェストの tag / commit ハッシュ
+
+`org.fcitx.Fcitx5.Addon.Hazkey.yml` 内の `tag:` と `commit:` フィールドは、
+ビルド対象の fcitx5-hazkey のバージョンを指定しています。
+リリース時には `tag:` をリリースタグに、`commit:` をそのタグのフルコミットハッシュに
+更新してください (`git rev-list -n1 <tag>` で取得できます)。

--- a/packaging/flatpak/install.sh
+++ b/packaging/flatpak/install.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -e
+
+LOCAL_BUILD=false
+if [ "$1" = "--local" ]; then
+    LOCAL_BUILD=true
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MANIFEST="$SCRIPT_DIR/org.fcitx.Fcitx5.Addon.Hazkey.yml"
+BUILD_DIR="$SCRIPT_DIR/build-dir"
+FLATPAK_REPO="$SCRIPT_DIR/hazkey-repo"
+REMOTE_NAME="hazkey-local"
+APP_ID="org.fcitx.Fcitx5.Addon.Hazkey"
+DESKTOP_FILE="org.fcitx.Fcitx5.Addon.Hazkey.hazkey-settings.desktop"
+
+# D-Bus 名のオーナーと flatpak ps から fcitx5 の実行状態を判定する
+# "flatpak" | "native" | "stopped"
+check_fcitx5_runtime() {
+    if flatpak ps --columns=application 2>/dev/null | grep -q org.fcitx.Fcitx5; then
+        echo "flatpak"
+    elif dbus-send --session --dest=org.freedesktop.DBus --type=method_call --print-reply \
+            /org/freedesktop/DBus org.freedesktop.DBus.NameHasOwner string:"org.fcitx.Fcitx5" \
+            2>/dev/null | grep -q "true"; then
+        echo "native"
+    else
+        echo "stopped"
+    fi
+}
+
+missing_cmds=()
+for cmd in flatpak flatpak-builder appstreamcli; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        missing_cmds+=("$cmd")
+    fi
+done
+if [ ${#missing_cmds[@]} -gt 0 ]; then
+    echo "エラー: 以下のコマンドがインストールされていません: ${missing_cmds[*]}" >&2
+    exit 1
+fi
+
+if [ "$(check_fcitx5_runtime)" = "native" ]; then
+    echo "警告: ネイティブ版の fcitx5 が動作しています。" >&2
+    echo "この Flatpak 拡張は Flatpak 版の Fcitx5 でのみ使用できます。" >&2
+    echo "続行しますか？ [y/N]"
+    read -r reply
+    if [ "$reply" != "y" ] && [ "$reply" != "Y" ]; then
+        echo "中断しました。"
+        exit 0
+    fi
+fi
+
+# flatpak info は --user/system 両方を検索する
+if ! flatpak info org.fcitx.Fcitx5//stable >/dev/null 2>&1; then
+    echo "org.fcitx.Fcitx5 ランタイムをインストールしています..."
+    flatpak install --user -y flathub org.fcitx.Fcitx5//stable
+fi
+
+if ! flatpak info org.kde.Sdk//6.9 >/dev/null 2>&1; then
+    echo "org.kde.Sdk//6.9 をインストールしています..."
+    flatpak install --user -y flathub org.kde.Sdk//6.9
+fi
+
+EXTRA_BUILDER_ARGS=()
+if [ "$LOCAL_BUILD" = true ]; then
+    REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    BUILD_MANIFEST="$SCRIPT_DIR/org.fcitx.Fcitx5.Addon.Hazkey.local.yml"
+    LOCAL_SRC="$SCRIPT_DIR/local-src"
+
+    # type: dir は .gitignore を尊重しないため、.flatpak-builder/ 等のビルド成果物も
+    # コピーされてしまう。git ls-files で追跡中のファイルのみをコピーする。
+    # rsync の --filter=':- .gitignore' は .gitignore の否定パターン (!) を
+    # サポートしないため使用できない (llama.cpp が build* + !build-info.cmake を使う)。
+    rm -rf "$LOCAL_SRC"
+    mkdir -p "$LOCAL_SRC"
+    echo "ローカルソース ($REPO_ROOT) をクリーンコピーしています..."
+    git -C "$REPO_ROOT" ls-files -z --recurse-submodules | rsync -a --files-from=- --from0 "$REPO_ROOT/" "$LOCAL_SRC/"
+    rsync -a "$REPO_ROOT/.git" "$LOCAL_SRC/"  # llama.cpp の cmake が git コマンドを実行するため
+    echo "ローカルソース ($REPO_ROOT) を使用してビルドします"
+
+    # rofiles-fuse が前のモジュールでインストールされたバイナリ (Swift ツールチェーンの
+    # clang 等) をハードリンク+読み取り専用にするため、後続モジュールのビルドで
+    # "openat: Permission denied" が発生する。ローカルビルドではキャッシュの整合性より
+    # ビルド成功を優先し、rofiles-fuse を無効化する。
+    EXTRA_BUILDER_ARGS+=(--disable-rofiles-fuse)
+else
+    BUILD_MANIFEST="$MANIFEST"
+fi
+
+echo "ビルドしています... (出力先: $FLATPAK_REPO)"
+flatpak-builder --user --force-clean --repo="$FLATPAK_REPO" "${EXTRA_BUILDER_ARGS[@]}" "$BUILD_DIR" "$BUILD_MANIFEST"
+
+# --force: 既存 ref があっても削除 (直後に再インストールするため)
+flatpak remote-delete --user --force "$REMOTE_NAME" 2>/dev/null || true
+flatpak remote-add --user --no-gpg-verify "$REMOTE_NAME" "$FLATPAK_REPO"
+
+echo "$APP_ID をインストールしています..."
+flatpak install --user -y --or-update "$REMOTE_NAME" "$APP_ID"
+
+# Flatpak は拡張のデスクトップエントリ・アイコンをエクスポートしないため
+# (flatpak/flatpak#4006, #5888)、手動でホスト側にコピーする。
+DESKTOP_SRC="$SCRIPT_DIR/$DESKTOP_FILE"
+DESKTOP_DST="$HOME/.local/share/applications/$DESKTOP_FILE"
+if [ -f "$DESKTOP_SRC" ]; then
+    mkdir -p "$HOME/.local/share/applications"
+    cp "$DESKTOP_SRC" "$DESKTOP_DST"
+    echo "デスクトップエントリをインストールしました: $DESKTOP_DST"
+fi
+
+EXTENSION_LOCATION="$(flatpak info --show-location --user "$APP_ID//stable")"
+icons_copied=false
+if [ -d "$EXTENSION_LOCATION/files/share/icons" ]; then
+    for icon in "$EXTENSION_LOCATION/files/share/icons/hicolor/"*"/apps/"*; do
+        if [ -f "$icon" ]; then
+            size_dir="$(basename "$(dirname "$(dirname "$icon")")")"
+            dest_dir="$HOME/.local/share/icons/hicolor/$size_dir/apps"
+            mkdir -p "$dest_dir"
+            cp "$icon" "$dest_dir/"
+            icons_copied=true
+        fi
+    done
+fi
+if [ "$icons_copied" = true ]; then
+    echo "アイコンをインストールしました"
+else
+    echo "警告: アイコンが見つかりませんでした" >&2
+fi
+
+"$SCRIPT_DIR/reload_cache.sh"
+
+# Flatpak 拡張のマウントはプロセス起動時に確定するため、設定リロードでは不十分で再起動が必要。
+case "$(check_fcitx5_runtime)" in
+    flatpak)
+        echo "Fcitx5 を再起動しています..."
+        flatpak kill org.fcitx.Fcitx5
+        sleep 1  # セッションマネージャによる自動再起動を待つ
+        if [ "$(check_fcitx5_runtime)" = "stopped" ]; then
+            flatpak run org.fcitx.Fcitx5 &
+            disown
+            sleep 1
+        fi
+        echo "Fcitx5 を再起動しました"
+        ;;
+    native)
+        echo "注意: Fcitx5 がホスト側で動作しています。"
+        echo "この Flatpak 拡張を使用するには、Flatpak 版の Fcitx5 で起動してください。"
+        ;;
+    stopped)
+        echo "注意: Flatpak 版の Fcitx5 が起動していません。Fcitx5 を起動してください。"
+        ;;
+esac
+
+echo ""
+echo "インストール完了!"
+echo "タスクバーのキーボードアイコンを右クリックし、Fcitx5 の設定から Hazkey を入力メソッドに追加してください。"
+echo ""
+echo "ヒント: 変換精度を向上させるには、Hazkey 設定ツールから Zenzai モデルをダウンロードしてください。"
+echo "  アプリランチャーから「Hazkey Settings」を起動 → AI タブからモデルをダウンロードできます。"

--- a/packaging/flatpak/modules/protobuf.yml
+++ b/packaging/flatpak/modules/protobuf.yml
@@ -1,0 +1,11 @@
+name: protobuf
+buildsystem: cmake-ninja
+builddir: true
+config-opts:
+  - -DCMAKE_BUILD_TYPE=Release
+  - -Dprotobuf_BUILD_TESTS=OFF
+  - -Dprotobuf_BUILD_SHARED_LIBS=ON
+sources:
+  - type: archive
+    url: https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protobuf-cpp-3.21.12.tar.gz
+    sha256: 4eab9b524aa5913c6fffb20b2a8abf5ef7f95a80bc0701f3a6dbb4c607f73460

--- a/packaging/flatpak/modules/swift-toolchain.yml
+++ b/packaging/flatpak/modules/swift-toolchain.yml
@@ -1,0 +1,30 @@
+name: swift-toolchain
+buildsystem: simple
+only-arches:
+  - x86_64
+  - aarch64
+build-commands:
+  - mkdir -p ${FLATPAK_DEST}/swift
+  - tar xf swift-${FLATPAK_ARCH}.tar.gz --strip-components=2 -C ${FLATPAK_DEST}/swift
+  # Swift ツールチェーン (Ubuntu 24.04 向けビルド) は libxml2.so.2 を要求するが、
+  # freedesktop SDK 24.08+ (KDE SDK 6.9+) は libxml2.so.16 を提供する。
+  # このワークアラウンドは Swift ツールチェーンが Ubuntu 24.04 をターゲットにしている間必要。
+  # Swift バージョン更新時は、新しいツールチェーンがまだ libxml2.so.2 をリンクしているか確認:
+  #   readelf -d swift/lib/libsourcekitdInProc.so | grep libxml2
+  # FLATPAK_ARCH で正しい multiarch ライブラリパスを解決する。
+  - ln -sf /usr/lib/${FLATPAK_ARCH}-linux-gnu/libxml2.so ${FLATPAK_DEST}/swift/lib/libxml2.so.2
+cleanup:
+  - /swift
+sources:
+  - type: file
+    only-arches:
+      - x86_64
+    url: https://download.swift.org/swift-6.2.4-release/ubuntu2404/swift-6.2.4-RELEASE/swift-6.2.4-RELEASE-ubuntu24.04.tar.gz
+    sha256: 15608c4fa0364ef906014343d81639cf58169e8a40de2b2d3503c3f35a8bb66d
+    dest-filename: swift-x86_64.tar.gz
+  - type: file
+    only-arches:
+      - aarch64
+    url: https://download.swift.org/swift-6.2.4-release/ubuntu2404-aarch64/swift-6.2.4-RELEASE/swift-6.2.4-RELEASE-ubuntu24.04-aarch64.tar.gz
+    sha256: 420bcde2ee4b2a36e49524b15373d0cb24eb4b679103f8cc8349af8a768832b7
+    dest-filename: swift-aarch64.tar.gz

--- a/packaging/flatpak/org.fcitx.Fcitx5.Addon.Hazkey.hazkey-settings.desktop
+++ b/packaging/flatpak/org.fcitx.Fcitx5.Addon.Hazkey.hazkey-settings.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Type=Application
+Name[ja]=Hazkey設定ツール
+Name=Hazkey Settings
+GenericName[ja]=入力メソッドの設定
+GenericName=Input Method Settings
+Comment[ja]=Hazkeyの設定を変更します
+Comment=Configure Hazkey settings
+# flatpak 内の PATH に `/app/addons/Hazkey/bin` が含まれないため、フルパスで指定する
+Exec=flatpak run --command=/app/addons/Hazkey/bin/hazkey-settings org.fcitx.Fcitx5
+Icon=org.fcitx.Fcitx5.Addon.Hazkey
+StartupNotify=true
+Categories=Settings;

--- a/packaging/flatpak/org.fcitx.Fcitx5.Addon.Hazkey.local.yml
+++ b/packaging/flatpak/org.fcitx.Fcitx5.Addon.Hazkey.local.yml
@@ -1,0 +1,66 @@
+# ローカルビルド用マニフェスト。install.sh --local で使用される。
+# ビルドオプションやモジュールを変更する場合は org.fcitx.Fcitx5.Addon.Hazkey.yml も更新すること。
+app-id: org.fcitx.Fcitx5.Addon.Hazkey
+runtime: org.fcitx.Fcitx5
+runtime-version: stable
+# Swift の C++ interop が GCC 15 ヘッダーと互換性がないため (swiftlang/swift#81774)、
+# KDE SDK 6.10 (freedesktop SDK 25.08, GCC 15) ではなく 6.9 (GCC 14) を使用する。
+# 修正され次第 6.10+ に更新すること。
+sdk: org.kde.Sdk//6.9
+# Fcitx5 の拡張ポイントは version=stable を要求するため、
+# アドオンが実行時に検出されるには stable ブランチを使用する必要がある。
+default-branch: stable
+build-extension: true
+separate-locales: false
+
+build-options:
+  prefix: /app/addons/Hazkey
+  prepend-path: /app/addons/Hazkey/swift/bin:/app/addons/Hazkey/bin
+  prepend-pkg-config-path: /app/addons/Hazkey/lib/pkgconfig:/app/lib/pkgconfig
+  prepend-ld-library-path: /app/addons/Hazkey/swift/lib:/app/addons/Hazkey/lib:/app/lib
+  # no-debuginfo: debuginfo 分離ファイルを生成しない
+  # strip: バイナリからシンボルを除去する
+  # 両方指定が必要: no-debuginfo だけでは strip されず、strip だけでは debuginfo が生成される
+  no-debuginfo: true
+  strip: true
+  env:
+    CMAKE_PREFIX_PATH: /app/addons/Hazkey:/app
+  # Swift Package Manager が依存パッケージを取得するためにネットワークアクセスが必要。
+  # Flathub への公開時は事前取得したソースに置き換える必要がある。
+  build-args:
+    - --share=network
+
+cleanup:
+  - /bin/protoc*
+  - /include
+  - /lib/pkgconfig
+  - /lib/cmake
+  - /lib/libprotoc*
+  - '*.la'
+
+modules:
+  - modules/swift-toolchain.yml
+  - modules/protobuf.yml
+
+  - name: fcitx5-hazkey
+    buildsystem: cmake-ninja
+    builddir: true
+    build-options:
+      # GCC 15+ の C++ interop 問題を避けるため Swift ツールチェーンの clang を使用
+      # (swiftlang/swift#81774)。GCC 14 SDK でも問題なく使用可能。
+      env:
+        CC: /app/addons/Hazkey/swift/bin/clang
+        CXX: /app/addons/Hazkey/swift/bin/clang++
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DHAZKEY_FLATPAK=ON
+      - -DHAZKEY_SERVER_STATIC_SWIFT_STDLIB=ON
+      - -DHAZKEY_SERVER_ENABLE_ZENZAI=ON
+      - -DHAZKEY_SERVER_BUILD_LLAMA_LIBS=ON
+      - -DHAZKEY_SERVER_INSTALL_LLAMA_LIBS=ON
+      - -DHAZKEY_SERVER_INSTALL_DICTIONARY=ON
+      - -DGGML_VULKAN=ON
+    sources:
+      # install.sh --local が local-src/ にクリーンコピーしたソースを使用する
+      - type: dir
+        path: local-src

--- a/packaging/flatpak/org.fcitx.Fcitx5.Addon.Hazkey.yml
+++ b/packaging/flatpak/org.fcitx.Fcitx5.Addon.Hazkey.yml
@@ -1,0 +1,67 @@
+# ビルドオプションやモジュールを変更する場合は org.fcitx.Fcitx5.Addon.Hazkey.local.yml も更新すること。
+app-id: org.fcitx.Fcitx5.Addon.Hazkey
+runtime: org.fcitx.Fcitx5
+runtime-version: stable
+# Swift の C++ interop が GCC 15 ヘッダーと互換性がないため (swiftlang/swift#81774)、
+# KDE SDK 6.10 (freedesktop SDK 25.08, GCC 15) ではなく 6.9 (GCC 14) を使用する。
+# 修正され次第 6.10+ に更新すること。
+sdk: org.kde.Sdk//6.9
+# Fcitx5 の拡張ポイントは version=stable を要求するため、
+# アドオンが実行時に検出されるには stable ブランチを使用する必要がある。
+default-branch: stable
+build-extension: true
+separate-locales: false
+
+build-options:
+  prefix: /app/addons/Hazkey
+  prepend-path: /app/addons/Hazkey/swift/bin:/app/addons/Hazkey/bin
+  prepend-pkg-config-path: /app/addons/Hazkey/lib/pkgconfig:/app/lib/pkgconfig
+  prepend-ld-library-path: /app/addons/Hazkey/swift/lib:/app/addons/Hazkey/lib:/app/lib
+  # no-debuginfo: debuginfo 分離ファイルを生成しない
+  # strip: バイナリからシンボルを除去する
+  # 両方指定が必要: no-debuginfo だけでは strip されず、strip だけでは debuginfo が生成される
+  no-debuginfo: true
+  strip: true
+  env:
+    CMAKE_PREFIX_PATH: /app/addons/Hazkey:/app
+  # Swift Package Manager が依存パッケージを取得するためにネットワークアクセスが必要。
+  # Flathub への公開時は事前取得したソースに置き換える必要がある。
+  build-args:
+    - --share=network
+
+cleanup:
+  - /bin/protoc*
+  - /include
+  - /lib/pkgconfig
+  - /lib/cmake
+  - /lib/libprotoc*
+  - '*.la'
+
+modules:
+  - modules/swift-toolchain.yml
+  - modules/protobuf.yml
+
+  - name: fcitx5-hazkey
+    buildsystem: cmake-ninja
+    builddir: true
+    build-options:
+      # GCC 15+ の C++ interop 問題を避けるため Swift ツールチェーンの clang を使用
+      # (swiftlang/swift#81774)。GCC 14 SDK でも問題なく使用可能。
+      env:
+        CC: /app/addons/Hazkey/swift/bin/clang
+        CXX: /app/addons/Hazkey/swift/bin/clang++
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DHAZKEY_FLATPAK=ON
+      - -DHAZKEY_SERVER_STATIC_SWIFT_STDLIB=ON
+      - -DHAZKEY_SERVER_ENABLE_ZENZAI=ON
+      - -DHAZKEY_SERVER_BUILD_LLAMA_LIBS=ON
+      - -DHAZKEY_SERVER_INSTALL_LLAMA_LIBS=ON
+      - -DHAZKEY_SERVER_INSTALL_DICTIONARY=ON
+      - -DGGML_VULKAN=ON
+    sources:
+      - type: git
+        url: https://github.com/7ka-Hiira/fcitx5-hazkey
+        tag: 0.2.1
+        commit: 596108c126449abcce2716a3e20d80106fb83890
+        disable-submodules: false

--- a/packaging/flatpak/reload_cache.sh
+++ b/packaging/flatpak/reload_cache.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# デスクトップエントリ・アイコンのキャッシュを再構築する。
+# install.sh / uninstall.sh から呼び出される。
+
+# KDE
+if command -v kbuildsycoca6 >/dev/null 2>&1; then
+    kbuildsycoca6 2>/dev/null || echo "警告: kbuildsycoca6 の実行に失敗しました (キャッシュは次回ログイン時に更新されます)" >&2
+fi
+
+# GNOME / Cinnamon / GTK ベースの DE
+if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database -q "$HOME/.local/share/applications" 2>/dev/null || echo "警告: update-desktop-database の実行に失敗しました" >&2
+fi
+
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+    gtk-update-icon-cache -q "$HOME/.local/share/icons/hicolor" 2>/dev/null || echo "警告: gtk-update-icon-cache の実行に失敗しました" >&2
+fi

--- a/packaging/flatpak/uninstall.sh
+++ b/packaging/flatpak/uninstall.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BUILD_DIR="$SCRIPT_DIR/build-dir"
+FLATPAK_REPO="$SCRIPT_DIR/hazkey-repo"
+REMOTE_NAME="hazkey-local"
+APP_ID="org.fcitx.Fcitx5.Addon.Hazkey"
+DESKTOP_FILE="org.fcitx.Fcitx5.Addon.Hazkey.hazkey-settings.desktop"
+
+# 拡張がマウント中だとアンインストールできないため、先に停止する。
+if flatpak ps --columns=application 2>/dev/null | grep -q org.fcitx.Fcitx5; then
+    echo "Fcitx5 を停止しています..."
+    flatpak kill org.fcitx.Fcitx5
+    sleep 1
+fi
+
+if flatpak info --user "$APP_ID" >/dev/null 2>&1; then
+    echo "$APP_ID をアンインストールしています..."
+    flatpak uninstall --user -y "$APP_ID"
+else
+    echo "$APP_ID はインストールされていません。"
+fi
+
+if flatpak remotes --user | grep -q "$REMOTE_NAME"; then
+    echo "リモート $REMOTE_NAME を削除しています..."
+    flatpak remote-delete --user "$REMOTE_NAME"
+fi
+
+if [ -d "$FLATPAK_REPO" ]; then
+    echo "ローカルリポジトリを削除しています: $FLATPAK_REPO"
+    rm -rf "$FLATPAK_REPO"
+fi
+
+if [ -d "$BUILD_DIR" ]; then
+    echo "ビルドディレクトリを削除しています: $BUILD_DIR"
+    rm -rf "$BUILD_DIR"
+fi
+
+# install.sh が手動コピーしたデスクトップエントリ・アイコンを掃除 (flatpak/flatpak#4006, #5888)
+DESKTOP_DST="$HOME/.local/share/applications/$DESKTOP_FILE"
+if [ -f "$DESKTOP_DST" ]; then
+    rm "$DESKTOP_DST"
+    echo "デスクトップエントリを削除しました: $DESKTOP_DST"
+fi
+
+ICON_NAME="org.fcitx.Fcitx5.Addon.Hazkey"
+icons_removed=false
+for icon in "$HOME/.local/share/icons/hicolor/"*"/apps/$ICON_NAME."*; do
+    if [ -f "$icon" ]; then
+        rm "$icon"
+        icons_removed=true
+    fi
+done
+if [ "$icons_removed" = true ]; then
+    echo "アイコンを削除しました: $ICON_NAME"
+fi
+
+"$SCRIPT_DIR/reload_cache.sh"
+
+if [ -d "$SCRIPT_DIR/.flatpak-builder" ]; then
+    echo ""
+    echo "注意: flatpak-builder のキャッシュ ($SCRIPT_DIR/.flatpak-builder) が残っています。"
+    echo "不要であれば手動で削除してください: rm -rf $SCRIPT_DIR/.flatpak-builder"
+fi
+
+if flatpak info org.fcitx.Fcitx5//stable >/dev/null 2>&1; then
+    if ! flatpak ps --columns=application 2>/dev/null | grep -q org.fcitx.Fcitx5; then
+        echo "Fcitx5 を再起動しています..."
+        flatpak run org.fcitx.Fcitx5 &
+        disown
+        sleep 1
+    fi
+fi
+
+echo "完了しました。"


### PR DESCRIPTION
## サマリー

Flatpak 版 Fcitx5 の拡張アドオンとして hazkey をパッケージしました。

### 新規ファイル

- `org.fcitx.Fcitx5.Addon.Hazkey.yml` とローカルインストール版を作成
- `install.sh` / `uninstall.sh` でローカルビルド・インストール・アンインストールを自動化

### 既存ファイルの変更

- `HAZKEY_ICON_NAME` の Flatpak 分岐を app-id (`org.fcitx.Fcitx5.Addon.Hazkey`) に統一し、SVG のリネームも追加
- `HAZKEY_SETTINGS_COMMAND` を追加 (Flatpak sandbox 内で `hazkey-settings` を起動するため)
- hsetDesktopFileName() の追加 (hazkey-settings のウィンドウアイコンが表示されなかったため)

## Flathub 公開に向けた既知の課題

詳細は `packaging/flatpak/README.md` を参照してください。

1. SwiftPM の依存取得に `--share=network` が必要 (Flathub では禁止)
2. Swift の GCC 15 互換性問題により KDE SDK 6.9 に固定
3. Flatpak が拡張のデスクトップエントリ・アイコンをエクスポートしない
4. AppStream メタデータ未作成

## その他今後必要なこと

- (既知の課題>3 解決後) Flatpak リポジトリをセルフホストする
- [fcitx/flatpak-fcitx5](https://github.com/fcitx/flatpak-fcitx5) にこのマニフェストを追加
- (既知の課題解決後) Flathub に公開

## Test plan

- [x] `packaging/flatpak/install.sh` でビルド・インストールが成功する
- [x] `packaging/flatpak/install.sh --local` でローカルソースからのビルドが成功する
- [x] Hazkey が入力メソッドとして利用可能
- [x] アプリランチャーに Hazkey Settings が表示される
- [x] `packaging/flatpak/uninstall.sh` でクリーンにアンインストールできる