### PR TITLE
feat: support clause boundary adjustment with Shift+Left/Right, Related to #6

### DIFF
--- a/fcitx5-hazkey/src/hazkey_server_connector.cpp
+++ b/fcitx5-hazkey/src/hazkey_server_connector.cpp
@@ -419,6 +419,30 @@ void HazkeyServerConnector::moveCursor(int offset) {
     return;
 }
 
+std::optional<HazkeyServerConnector::ClauseBoundaryResult>
+HazkeyServerConnector::adjustClauseBoundary(int offset) {
+    hazkey::RequestEnvelope request;
+    auto props = request.mutable_adjust_clause_boundary();
+    props->set_offset(offset);
+    auto response = transact(request);
+    if (response == std::nullopt) {
+        FCITX_ERROR() << "Error while transacting adjustClauseBoundary().";
+        return std::nullopt;
+    }
+    auto responseVal = response.value();
+    if (responseVal.status() != hazkey::SUCCESS) {
+        FCITX_ERROR() << "adjustClauseBoundary: "
+                      << "Server returned an error: "
+                      << responseVal.error_message();
+        return std::nullopt;
+    }
+
+    ClauseBoundaryResult result;
+    result.candidates = responseVal.clause_boundary_result().candidates();
+    result.hiragana = responseVal.clause_boundary_result().hiragana();
+    return result;
+}
+
 void HazkeyServerConnector::setContext(std::string context, int anchor) {
     hazkey::RequestEnvelope request;
     auto props = request.mutable_set_context();

--- a/fcitx5-hazkey/src/hazkey_server_connector.h
+++ b/fcitx5-hazkey/src/hazkey_server_connector.h
@@ -49,6 +49,13 @@ class HazkeyServerConnector {
 
     void moveCursor(int offset);
 
+    struct ClauseBoundaryResult {
+        hazkey::commands::CandidatesResult candidates;
+        std::string hiragana;
+    };
+
+    std::optional<ClauseBoundaryResult> adjustClauseBoundary(int offset);
+
     void setContext(std::string context, int anchor);
 
     void setServerConfig(int zenzaiEnabled, int zenzaiInferLimit,

--- a/fcitx5-hazkey/src/hazkey_state.cpp
+++ b/fcitx5-hazkey/src/hazkey_state.cpp
@@ -176,11 +176,19 @@ void HazkeyState::preeditKeyEvent(
             }
             break;
         case FcitxKey_Left:
-            isCursorMoving_ = true;
-            engine_->server().moveCursor(-1);
+            if (key.states() == KeyState::Shift) {
+                showNonPredictCandidateList();
+                moveSegmentBoundary(false);
+            } else {
+                isCursorMoving_ = true;
+                engine_->server().moveCursor(-1);
+            }
             break;
         case FcitxKey_Right:
-            if (isCursorMoving_) {
+            if (key.states() == KeyState::Shift) {
+                showNonPredictCandidateList();
+                moveSegmentBoundary(true);
+            } else if (isCursorMoving_) {
                 engine_->server().moveCursor(1);
             }
             break;

--- a/fcitx5-hazkey/src/hazkey_state.cpp
+++ b/fcitx5-hazkey/src/hazkey_state.cpp
@@ -227,19 +227,29 @@ void HazkeyState::candidateKeyEvent(
     std::vector<std::string> preedit;
     switch (keysym) {
         case FcitxKey_Right:
-            // if (event.key().states() == KeyState::Alt) {
-            candidateList->nextPage();
-            // }
+            if (key.states() == KeyState::Shift) {
+                moveSegmentBoundary(true);
+            } else {
+                candidateList->nextPage();
+            }
             break;
         case FcitxKey_Left:
-            // if (event.key().states() == KeyState::Alt) {
-            candidateList->prevPage();
-            // }
+            if (key.states() == KeyState::Shift) {
+                moveSegmentBoundary(false);
+            } else {
+                candidateList->prevPage();
+            }
             break;
         case FcitxKey_Return:
             candidateCompleteHandler(candidateList);
             break;
         case FcitxKey_Escape:
+            if (isClauseBoundaryAdjusting_) {
+                showNonPredictCandidateList(false);
+                break;
+            }
+            isClauseBoundaryAdjusting_ = false;
+            [[fallthrough]];
         case FcitxKey_BackSpace:
             showPreeditCandidateList();
             break;
@@ -306,7 +316,8 @@ void HazkeyState::candidateCompleteHandler(
     engine_->server().completePrefix(candidateList->globalCursorIndex());
     ic_->commitString(preedit[0]);
     if (preedit.size() > 1) {
-        showNonPredictCandidateList();
+        isClauseBoundaryAdjusting_ = false;
+        showNonPredictCandidateList(false);
     } else {
         reset();
     }
@@ -468,7 +479,11 @@ bool HazkeyState::showCandidateList(bool isSuggest) {
     return response.page_size() > 0;
 }
 
-void HazkeyState::showNonPredictCandidateList() {
+void HazkeyState::showNonPredictCandidateList(bool preserveTarget) {
+    if (!preserveTarget) {
+        engine_->server().moveCursor(1024);
+        isClauseBoundaryAdjusting_ = false;
+    }
     showCandidateList(false);
 
     livePreeditIndex_ = -1;
@@ -524,6 +539,12 @@ void HazkeyState::backCandidateCursor(
     updateCandidateCursor(candidateList);
 }
 
+void HazkeyState::moveSegmentBoundary(bool expand) {
+    isClauseBoundaryAdjusting_ = true;
+    engine_->server().moveCursor(expand ? 1 : -1);
+    showNonPredictCandidateList(true);
+}
+
 /// AUX
 
 void HazkeyState::setCandidateCursorAUX(
@@ -557,6 +578,7 @@ void HazkeyState::reset() {
     isDirectConversionMode_ = false;
     livePreeditIndex_ = -1;
     isCursorMoving_ = false;
+    isClauseBoundaryAdjusting_ = false;
     engine_->server().newComposingText();
     ic_->inputPanel().reset();
 }

--- a/fcitx5-hazkey/src/hazkey_state.cpp
+++ b/fcitx5-hazkey/src/hazkey_state.cpp
@@ -438,12 +438,17 @@ void HazkeyState::directCharactorConversion(ConversionMode mode) {
 /// Show Candidate List
 
 bool HazkeyState::showCandidateList(bool isSuggest) {
+    auto response = engine_->server().getCandidates(isSuggest);
+    return showCandidateList(response);
+}
+
+bool HazkeyState::showCandidateList(
+    const hazkey::commands::CandidatesResult& response,
+    std::optional<std::string> fallbackPreedit) {
     FCITX_DEBUG() << "HazkeyState showCandidateList";
 
-    auto response = engine_->server().getCandidates(isSuggest);
-
     auto candidateResult =
-        std::make_unique<HazkeyCandidateList>(std::move(response.candidates()));
+        std::make_unique<HazkeyCandidateList>(response.candidates());
 
     candidateResult->setSelectionKey(defaultSelectionKeys);
 
@@ -454,6 +459,8 @@ bool HazkeyState::showCandidateList(bool isSuggest) {
         // preedit conversion is enabled and conversion result is found
         // show preedit conversion result
         preedit_.setSimplePreedit(response.live_text());
+    } else if (fallbackPreedit != std::nullopt) {
+        preedit_.setSimplePreedit(*fallbackPreedit);
     } else {
         // preedit conversion is disabled or conversion result is not
         // available show hiragana preedit
@@ -492,6 +499,23 @@ void HazkeyState::showNonPredictCandidateList(bool preserveTarget) {
     // because the first candidate is the result of all preedit text.
     auto currentPreedit = preedit_.text();
     preedit_.setSimplePreeditHighlighted(currentPreedit);
+
+    auto newCandidateList = std::dynamic_pointer_cast<HazkeyCandidateList>(
+        ic_->inputPanel().candidateList());
+    newCandidateList->focus();
+    updateCandidateCursor(newCandidateList);
+    setCandidateCursorAUX(
+        std::static_pointer_cast<HazkeyCandidateList>(newCandidateList));
+}
+
+void HazkeyState::showNonPredictCandidateList(
+    const hazkey::commands::CandidatesResult& response,
+    const std::string& hiragana) {
+    showCandidateList(response, hiragana);
+
+    livePreeditIndex_ = -1;
+
+    preedit_.setSimplePreeditHighlighted(hiragana);
 
     auto newCandidateList = std::dynamic_pointer_cast<HazkeyCandidateList>(
         ic_->inputPanel().candidateList());
@@ -541,8 +565,11 @@ void HazkeyState::backCandidateCursor(
 
 void HazkeyState::moveSegmentBoundary(bool expand) {
     isClauseBoundaryAdjusting_ = true;
-    engine_->server().moveCursor(expand ? 1 : -1);
-    showNonPredictCandidateList(true);
+    auto result = engine_->server().adjustClauseBoundary(expand ? 1 : -1);
+    if (result == std::nullopt) {
+        return;
+    }
+    showNonPredictCandidateList(result->candidates, result->hiragana);
 }
 
 /// AUX

--- a/fcitx5-hazkey/src/hazkey_state.h
+++ b/fcitx5-hazkey/src/hazkey_state.h
@@ -66,7 +66,7 @@ class HazkeyState : public InputContextProperty {
         std::shared_ptr<std::vector<std::string>> preeditSegments);
 
     // prepare candidate list for normal conversion
-    void showNonPredictCandidateList();
+    void showNonPredictCandidateList(bool preserveTarget = false);
     // prepare candidate
     // list for prediction.
     // shorter than normal
@@ -87,6 +87,7 @@ class HazkeyState : public InputContextProperty {
     // preedit text
     void backCandidateCursor(
         std::shared_ptr<HazkeyCandidateList> candidateList);
+    void moveSegmentBoundary(bool expand);
     // update aux; label on
     // the candidate list
     // like "[1/100]"
@@ -106,6 +107,7 @@ class HazkeyState : public InputContextProperty {
     bool isAltDigitKeyEvent(const KeyEvent& keyEvent);
 
     bool isCursorMoving_ = false;
+    bool isClauseBoundaryAdjusting_ = false;
 
     bool isDirectConversionMode_ = false;
     int livePreeditIndex_ = -1;

--- a/fcitx5-hazkey/src/hazkey_state.h
+++ b/fcitx5-hazkey/src/hazkey_state.h
@@ -61,12 +61,18 @@ class HazkeyState : public InputContextProperty {
     // base function to prepare candidate list
     // make sure composingText_ is not nullptr
     bool showCandidateList(bool isSuggest);
+    bool showCandidateList(
+        const hazkey::commands::CandidatesResult &response,
+        std::optional<std::string> fallbackPreedit = std::nullopt);
     std::unique_ptr<HazkeyCandidateList> createCandidateList(
         std::vector<std::vector<std::string>> candidates,
         std::shared_ptr<std::vector<std::string>> preeditSegments);
 
     // prepare candidate list for normal conversion
     void showNonPredictCandidateList(bool preserveTarget = false);
+    void showNonPredictCandidateList(
+        const hazkey::commands::CandidatesResult &response,
+        const std::string &hiragana);
     // prepare candidate
     // list for prediction.
     // shorter than normal

--- a/hazkey-server/Sources/hazkey-server/Protocol/base.pb.swift
+++ b/hazkey-server/Sources/hazkey-server/Protocol/base.pb.swift
@@ -169,6 +169,14 @@ struct Hazkey_RequestEnvelope: Sendable {
     set {payload = .saveLearningData(newValue)}
   }
 
+  var adjustClauseBoundary: Hazkey_Commands_AdjustClauseBoundary {
+    get {
+      if case .adjustClauseBoundary(let v)? = payload {return v}
+      return Hazkey_Commands_AdjustClauseBoundary()
+    }
+    set {payload = .adjustClauseBoundary(newValue)}
+  }
+
   var getConfig: Hazkey_Config_GetConfig {
     get {
       if case .getConfig(let v)? = payload {return v}
@@ -225,6 +233,7 @@ struct Hazkey_RequestEnvelope: Sendable {
     case getCandidates(Hazkey_Commands_GetCandidates)
     case getCurrentInputMode(Hazkey_Commands_GetCurrentInputModeInfo)
     case saveLearningData(Hazkey_Commands_SaveLearningData)
+    case adjustClauseBoundary(Hazkey_Commands_AdjustClauseBoundary)
     case getConfig(Hazkey_Config_GetConfig)
     case setConfig(Hazkey_Config_SetConfig)
     case getDefaultProfile(Hazkey_Config_GetDefaultProfile)
@@ -279,6 +288,14 @@ struct Hazkey_ResponseEnvelope: Sendable {
     set {payload = .currentInputModeInfo(newValue)}
   }
 
+  var clauseBoundaryResult: Hazkey_Commands_ClauseBoundaryResult {
+    get {
+      if case .clauseBoundaryResult(let v)? = payload {return v}
+      return Hazkey_Commands_ClauseBoundaryResult()
+    }
+    set {payload = .clauseBoundaryResult(newValue)}
+  }
+
   var currentConfig: Hazkey_Config_CurrentConfig {
     get {
       if case .currentConfig(let v)? = payload {return v}
@@ -294,6 +311,7 @@ struct Hazkey_ResponseEnvelope: Sendable {
     case candidates(Hazkey_Commands_CandidatesResult)
     case textWithCursor(Hazkey_Commands_TextWithCursor)
     case currentInputModeInfo(Hazkey_Commands_CurrentInputModeInfo)
+    case clauseBoundaryResult(Hazkey_Commands_ClauseBoundaryResult)
     case currentConfig(Hazkey_Config_CurrentConfig)
 
   }
@@ -329,6 +347,7 @@ extension Hazkey_RequestEnvelope: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     11: .standard(proto: "get_candidates"),
     12: .standard(proto: "get_current_input_mode"),
     13: .standard(proto: "save_learning_data"),
+    14: .standard(proto: "adjust_clause_boundary"),
     100: .standard(proto: "get_config"),
     101: .standard(proto: "set_config"),
     102: .standard(proto: "get_default_profile"),
@@ -511,6 +530,19 @@ extension Hazkey_RequestEnvelope: SwiftProtobuf.Message, SwiftProtobuf._MessageI
           self.payload = .saveLearningData(v)
         }
       }()
+      case 14: try {
+        var v: Hazkey_Commands_AdjustClauseBoundary?
+        var hadOneofValue = false
+        if let current = self.payload {
+          hadOneofValue = true
+          if case .adjustClauseBoundary(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payload = .adjustClauseBoundary(v)
+        }
+      }()
       case 100: try {
         var v: Hazkey_Config_GetConfig?
         var hadOneofValue = false
@@ -639,6 +671,10 @@ extension Hazkey_RequestEnvelope: SwiftProtobuf.Message, SwiftProtobuf._MessageI
       guard case .saveLearningData(let v)? = self.payload else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
     }()
+    case .adjustClauseBoundary?: try {
+      guard case .adjustClauseBoundary(let v)? = self.payload else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 14)
+    }()
     case .getConfig?: try {
       guard case .getConfig(let v)? = self.payload else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 100)
@@ -680,6 +716,7 @@ extension Hazkey_ResponseEnvelope: SwiftProtobuf.Message, SwiftProtobuf._Message
     4: .same(proto: "candidates"),
     5: .standard(proto: "text_with_cursor"),
     6: .standard(proto: "current_input_mode_info"),
+    7: .standard(proto: "clause_boundary_result"),
     100: .standard(proto: "current_config"),
   ]
 
@@ -738,6 +775,19 @@ extension Hazkey_ResponseEnvelope: SwiftProtobuf.Message, SwiftProtobuf._Message
           self.payload = .currentInputModeInfo(v)
         }
       }()
+      case 7: try {
+        var v: Hazkey_Commands_ClauseBoundaryResult?
+        var hadOneofValue = false
+        if let current = self.payload {
+          hadOneofValue = true
+          if case .clauseBoundaryResult(let m) = current {v = m}
+        }
+        try decoder.decodeSingularMessageField(value: &v)
+        if let v = v {
+          if hadOneofValue {try decoder.handleConflictingOneOf()}
+          self.payload = .clauseBoundaryResult(v)
+        }
+      }()
       case 100: try {
         var v: Hazkey_Config_CurrentConfig?
         var hadOneofValue = false
@@ -783,6 +833,10 @@ extension Hazkey_ResponseEnvelope: SwiftProtobuf.Message, SwiftProtobuf._Message
     case .currentInputModeInfo?: try {
       guard case .currentInputModeInfo(let v)? = self.payload else { preconditionFailure() }
       try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+    }()
+    case .clauseBoundaryResult?: try {
+      guard case .clauseBoundaryResult(let v)? = self.payload else { preconditionFailure() }
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
     }()
     case .currentConfig?: try {
       guard case .currentConfig(let v)? = self.payload else { preconditionFailure() }

--- a/hazkey-server/Sources/hazkey-server/Protocol/commands.pb.swift
+++ b/hazkey-server/Sources/hazkey-server/Protocol/commands.pb.swift
@@ -154,6 +154,18 @@ struct Hazkey_Commands_MoveCursor: Sendable {
   init() {}
 }
 
+struct Hazkey_Commands_AdjustClauseBoundary: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var offset: Int32 = 0
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+}
+
 struct Hazkey_Commands_PrefixComplete: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -346,6 +358,29 @@ struct Hazkey_Commands_CandidatesResult: Sendable {
   }
 
   init() {}
+}
+
+struct Hazkey_Commands_ClauseBoundaryResult: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var candidates: Hazkey_Commands_CandidatesResult {
+    get {return _candidates ?? Hazkey_Commands_CandidatesResult()}
+    set {_candidates = newValue}
+  }
+  /// Returns true if `candidates` has been explicitly set.
+  var hasCandidates: Bool {return self._candidates != nil}
+  /// Clears the value of `candidates`. Subsequent reads from it will return its default value.
+  mutating func clearCandidates() {self._candidates = nil}
+
+  var hiragana: String = String()
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+
+  fileprivate var _candidates: Hazkey_Commands_CandidatesResult? = nil
 }
 
 struct Hazkey_Commands_CurrentInputModeInfo: Sendable {
@@ -566,6 +601,38 @@ extension Hazkey_Commands_MoveCursor: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 
   static func ==(lhs: Hazkey_Commands_MoveCursor, rhs: Hazkey_Commands_MoveCursor) -> Bool {
+    if lhs.offset != rhs.offset {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Hazkey_Commands_AdjustClauseBoundary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".AdjustClauseBoundary"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "offset"),
+  ]
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularInt32Field(value: &self.offset) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.offset != 0 {
+      try visitor.visitSingularInt32Field(value: self.offset, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Hazkey_Commands_AdjustClauseBoundary, rhs: Hazkey_Commands_AdjustClauseBoundary) -> Bool {
     if lhs.offset != rhs.offset {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
@@ -938,6 +1005,48 @@ extension Hazkey_Commands_CandidatesResult.Candidate: SwiftProtobuf.Message, Swi
   static func ==(lhs: Hazkey_Commands_CandidatesResult.Candidate, rhs: Hazkey_Commands_CandidatesResult.Candidate) -> Bool {
     if lhs.text != rhs.text {return false}
     if lhs.subHiragana != rhs.subHiragana {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Hazkey_Commands_ClauseBoundaryResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".ClauseBoundaryResult"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "candidates"),
+    2: .same(proto: "hiragana"),
+  ]
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularMessageField(value: &self._candidates) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.hiragana) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._candidates {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
+    } }()
+    if !self.hiragana.isEmpty {
+      try visitor.visitSingularStringField(value: self.hiragana, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Hazkey_Commands_ClauseBoundaryResult, rhs: Hazkey_Commands_ClauseBoundaryResult) -> Bool {
+    if lhs._candidates != rhs._candidates {return false}
+    if lhs.hiragana != rhs.hiragana {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/hazkey-server/Sources/hazkey-server/protocolHandler.swift
+++ b/hazkey-server/Sources/hazkey-server/protocolHandler.swift
@@ -41,6 +41,8 @@ class ProtocolHandler {
             response = state.completePrefix(candidateIndex: Int(req.index))
         case .moveCursor(let req):
             response = state.moveCursor(offset: Int(req.offset))
+        case .adjustClauseBoundary(let req):
+            response = state.adjustClauseBoundary(offset: Int(req.offset))
         case .getHiraganaWithCursor:
             response = state.getHiraganaWithCursor()
         case .getComposingString(let req):

--- a/hazkey-server/Sources/hazkey-server/state.swift
+++ b/hazkey-server/Sources/hazkey-server/state.swift
@@ -203,6 +203,36 @@ class HazkeyServerState {
         }
     }
 
+    func adjustClauseBoundary(offset: Int) -> Hazkey_ResponseEnvelope {
+        if composingText.value.isEmpty {
+            return Hazkey_ResponseEnvelope.with {
+                $0.status = .success
+                $0.clauseBoundaryResult = Hazkey_Commands_ClauseBoundaryResult()
+            }
+        }
+
+        let minCursorPosition = 1
+        let maxBackwardOffset =
+            minCursorPosition - composingText.value.convertTargetCursorPosition
+        let maxForwardOffset =
+            composingText.value.convertTarget.count -
+            composingText.value.convertTargetCursorPosition
+        let clampedOffset = max(min(offset, maxForwardOffset), maxBackwardOffset)
+        _ = composingText.value.moveCursorFromCursorPosition(count: clampedOffset)
+
+        let (candidatesResult, serverCandidates) = makeCandidatesResult(
+            is_suggest: false)
+        currentCandidateList = serverCandidates
+
+        return Hazkey_ResponseEnvelope.with {
+            $0.status = .success
+            $0.clauseBoundaryResult = Hazkey_Commands_ClauseBoundaryResult.with {
+                $0.candidates = candidatesResult
+                $0.hiragana = composingText.value.toHiragana()
+            }
+        }
+    }
+
     /// ComposingText -> Characters
 
     func getHiraganaWithCursor() -> Hazkey_ResponseEnvelope {
@@ -297,8 +327,9 @@ class HazkeyServerState {
         return copiedComposingText
     }
 
-    // TODO: return error message
-    func getCandidates(is_suggest: Bool) -> Hazkey_ResponseEnvelope {
+    private func makeCandidatesResult(
+        is_suggest: Bool
+    ) -> (Hazkey_Commands_CandidatesResult, [Candidate]) {
 
         func canAppend(
             isSuggest: Bool,
@@ -401,7 +432,6 @@ class HazkeyServerState {
             )
         }
 
-        self.currentCandidateList = serverCandidates
         candidatesResult.candidates = clientCandidates
 
         // Do not automatically convert if there is only one character
@@ -430,6 +460,14 @@ class HazkeyServerState {
                 return serverConfig.currentProfile.numCandidatesPerPage
             }
         }()
+
+        return (candidatesResult, serverCandidates)
+    }
+
+    // TODO: return error message
+    func getCandidates(is_suggest: Bool) -> Hazkey_ResponseEnvelope {
+        let (candidatesResult, serverCandidates) = makeCandidatesResult(is_suggest: is_suggest)
+        self.currentCandidateList = serverCandidates
 
         return Hazkey_ResponseEnvelope.with {
             $0.status = .success

--- a/hazkey-server/Sources/hazkey-server/state.swift
+++ b/hazkey-server/Sources/hazkey-server/state.swift
@@ -278,6 +278,25 @@ class HazkeyServerState {
 
     /// Candidates
 
+    func candidateRequestText(is_suggest: Bool) -> ComposingText {
+        let usePrefixTarget = !is_suggest && !composingText.value.isAtEndIndex
+        var copiedComposingText =
+            usePrefixTarget
+            ? composingText.value.prefixToCursorPosition()
+            : composingText.value
+
+        if !is_suggest {
+            copiedComposingText.insertAtCursorPosition(
+                [
+                    ComposingText.InputElement(
+                        piece: .compositionSeparator,
+                        inputStyle: .mapped(id: .tableName(currentTableName)))
+                ])
+        }
+
+        return copiedComposingText
+    }
+
     // TODO: return error message
     func getCandidates(is_suggest: Bool) -> Hazkey_ResponseEnvelope {
 
@@ -291,16 +310,16 @@ class HazkeyServerState {
 
         func appendCandidate(
             _ candidate: Candidate,
-            hiraganaPreedit: String,
-            hiraganaPreeditLen: Int,
+            fullHiraganaPreedit: String,
+            requestHiraganaPreeditLen: Int,
             serverCandidates: inout [Candidate],
             clientCandidates: inout [Hazkey_Commands_CandidatesResult.Candidate]
         ) {
             var clientCandidate = Hazkey_Commands_CandidatesResult.Candidate()
             clientCandidate.text = candidate.text
 
-            let endIndex = min(candidate.rubyCount, hiraganaPreeditLen)
-            clientCandidate.subHiragana = String(hiraganaPreedit.dropFirst(endIndex))
+            let endIndex = min(candidate.rubyCount, requestHiraganaPreeditLen)
+            clientCandidate.subHiragana = String(fullHiraganaPreedit.dropFirst(endIndex))
 
             clientCandidates.append(clientCandidate)
             serverCandidates.append(candidate)
@@ -330,21 +349,11 @@ class HazkeyServerState {
 
         options.requireJapanesePrediction = usePrediction ? .manualMix : .disabled
 
-        var copiedComposingText = composingText.value
-
-        if !is_suggest {
-            let _ = copiedComposingText.moveCursorFromCursorPosition(
-                count: copiedComposingText.toHiragana().count)
-            copiedComposingText.insertAtCursorPosition(
-                [
-                    ComposingText.InputElement(
-                        piece: .compositionSeparator,
-                        inputStyle: .mapped(id: .tableName(currentTableName)))
-                ])
-        }
+        let copiedComposingText = candidateRequestText(is_suggest: is_suggest)
 
         var candidatesResult = Hazkey_Commands_CandidatesResult()
         let converted = converter.requestCandidates(copiedComposingText, options: options)
+        let fullHiraganaPreedit = composingText.value.toHiragana()
         let hiraganaPreedit = copiedComposingText.toHiragana()
         let hiraganaPreeditLen = hiraganaPreedit.count
         var serverCandidates: [Candidate] = []
@@ -358,7 +367,9 @@ class HazkeyServerState {
             else { break }
 
             appendCandidate(
-                candidate, hiraganaPreedit: hiraganaPreedit, hiraganaPreeditLen: hiraganaPreeditLen,
+                candidate,
+                fullHiraganaPreedit: fullHiraganaPreedit,
+                requestHiraganaPreeditLen: hiraganaPreeditLen,
                 serverCandidates: &serverCandidates,
                 clientCandidates: &clientCandidates)
         }
@@ -383,8 +394,8 @@ class HazkeyServerState {
 
             appendCandidate(
                 candidate,
-                hiraganaPreedit: hiraganaPreedit,
-                hiraganaPreeditLen: hiraganaPreeditLen,
+                fullHiraganaPreedit: fullHiraganaPreedit,
+                requestHiraganaPreeditLen: hiraganaPreeditLen,
                 serverCandidates: &serverCandidates,
                 clientCandidates: &clientCandidates
             )

--- a/hazkey-server/Sources/hazkey-server/state.swift
+++ b/hazkey-server/Sources/hazkey-server/state.swift
@@ -308,23 +308,25 @@ class HazkeyServerState {
 
     /// Candidates
 
+    func ensureCompositionSeparatorForConversion() {
+        guard composingText.value.isAtEndIndex else {
+            return
+        }
+        if composingText.value.input.last?.piece == .compositionSeparator {
+            return
+        }
+        composingText.value.insertAtCursorPosition([
+            ComposingText.InputElement(
+                piece: .compositionSeparator,
+                inputStyle: .mapped(id: .tableName(currentTableName)))
+        ])
+    }
+
     func candidateRequestText(is_suggest: Bool) -> ComposingText {
         let usePrefixTarget = !is_suggest && !composingText.value.isAtEndIndex
-        var copiedComposingText =
-            usePrefixTarget
+        return usePrefixTarget
             ? composingText.value.prefixToCursorPosition()
             : composingText.value
-
-        if !is_suggest {
-            copiedComposingText.insertAtCursorPosition(
-                [
-                    ComposingText.InputElement(
-                        piece: .compositionSeparator,
-                        inputStyle: .mapped(id: .tableName(currentTableName)))
-                ])
-        }
-
-        return copiedComposingText
     }
 
     private func makeCandidatesResult(
@@ -466,6 +468,9 @@ class HazkeyServerState {
 
     // TODO: return error message
     func getCandidates(is_suggest: Bool) -> Hazkey_ResponseEnvelope {
+        if !is_suggest {
+            ensureCompositionSeparatorForConversion()
+        }
         let (candidatesResult, serverCandidates) = makeCandidatesResult(is_suggest: is_suggest)
         self.currentCandidateList = serverCandidates
 

--- a/hazkey-server/Sources/hazkey-server/state.swift
+++ b/hazkey-server/Sources/hazkey-server/state.swift
@@ -204,6 +204,7 @@ class HazkeyServerState {
     }
 
     func adjustClauseBoundary(offset: Int) -> Hazkey_ResponseEnvelope {
+        isShiftPressedAlone = false
         if composingText.value.isEmpty {
             return Hazkey_ResponseEnvelope.with {
                 $0.status = .success

--- a/protocol/base.proto
+++ b/protocol/base.proto
@@ -22,6 +22,7 @@ message RequestEnvelope {
         hazkey.commands.GetCandidates get_candidates = 11;
         hazkey.commands.GetCurrentInputModeInfo get_current_input_mode = 12;
         hazkey.commands.SaveLearningData save_learning_data = 13;
+        hazkey.commands.AdjustClauseBoundary adjust_clause_boundary = 14;
 
         hazkey.config.GetConfig get_config = 100;
         hazkey.config.SetConfig set_config = 101;
@@ -45,6 +46,7 @@ message ResponseEnvelope {
         hazkey.commands.CandidatesResult candidates = 4;
         hazkey.commands.TextWithCursor text_with_cursor = 5;
         hazkey.commands.CurrentInputModeInfo current_input_mode_info = 6;
+        hazkey.commands.ClauseBoundaryResult clause_boundary_result = 7;
         hazkey.config.CurrentConfig current_config = 100;
     }
 }

--- a/protocol/commands.proto
+++ b/protocol/commands.proto
@@ -37,6 +37,10 @@ message MoveCursor {
     int32 offset = 1;
 }
 
+message AdjustClauseBoundary {
+    int32 offset = 1;
+}
+
 message PrefixComplete {
     int32 index = 1;
 }
@@ -90,6 +94,11 @@ message CandidatesResult {
     string live_text = 2;
     int32 live_text_index = 3;
     int32 page_size = 4;
+}
+
+message ClauseBoundaryResult {
+    CandidatesResult candidates = 1;
+    string hiragana = 2;
 }
 
 message CurrentInputModeInfo {


### PR DESCRIPTION
Issue #6 を解決するための機能を実装してみました!

## 変更内容

- 候補リストを表示したまま変換対象を調整できるようにする
  - Shift+Left/Right後に通常の変換候補を再生成
  - 部分確定後に未変換テキストの残りを保持
  - Escで文節境界調整から全体変換候補へ戻れるようにする

## テスト環境

- Kubuntu 26.04 (X11)

Kubuntu 24.04 でも動作確認はできていますが、ビルドのためにCMake周りへ追加の変更を加えた環境を使用しています。
なお、それらの変更は本PRの内容には含まれていません。

https://github.com/user-attachments/assets/68bd75a9-848f-41c4-bb17-0fa894af24c2

初めてのPull Requestですので、問題点などありましたらご指摘いただけると幸いです。