### PR TITLE
Ctrl-H を Backspace 相当に

### DIFF
--- a/fcitx5-hazkey/src/hazkey_state.cpp
+++ b/fcitx5-hazkey/src/hazkey_state.cpp
@@ -352,6 +352,11 @@ bool HazkeyState::ctrlShortcutHandler(KeyEvent& event) {
             directCharactorConversion(ConversionMode::RawHalfwidth);
             isDirectConversionMode_ = true;
             break;
+        case FcitxKey_h:
+        case FcitxKey_H:
+            engine_->server().deleteLeft();
+            showPreeditCandidateList();
+            break;
         default:
             FCITX_INFO() << "keysym" << keysym;
             return false;


### PR DESCRIPTION
Ctrl-H をBSキーとして使いたいです。キーバインドのカスタマイズができるようになるまでのつなぎとして Ctrl-H もハンドリングしてもらえると嬉しいです。手元の Ubuntu 22.04 環境では動いてますので PR として出しておきます。
よろしくお願いします。