### PR TITLE
fix: avoid empty preedit updates

### DIFF
--- a/fcitx5-hazkey/src/hazkey_engine.cpp
+++ b/fcitx5-hazkey/src/hazkey_engine.cpp
@@ -8,6 +8,18 @@
 
 namespace fcitx {
 
+namespace {
+
+bool hasVisiblePreedit(InputContext *inputContext) {
+    const auto &inputPanel = inputContext->inputPanel();
+    if (inputContext->capabilityFlags().test(CapabilityFlag::Preedit)) {
+        return !inputPanel.clientPreedit().toString().empty();
+    }
+    return !inputPanel.preedit().toString().empty();
+}
+
+}  // namespace
+
 HazkeyEngine::HazkeyEngine(Instance *instance)
     : instance_(instance), factory_([this](InputContext &ic) {
           return new HazkeyState(this, &ic);
@@ -24,7 +36,9 @@ void HazkeyEngine::keyEvent([[maybe_unused]] const InputMethodEntry &entry,
 
     auto inputContext = keyEvent.inputContext();
     inputContext->propertyFor(&factory_)->keyEvent(keyEvent);
-    inputContext->updatePreedit();
+    if (keyEvent.accepted()) {
+        inputContext->updatePreedit();
+    }
     inputContext->updateUserInterface(UserInterfaceComponent::InputPanel);
 }
 
@@ -35,7 +49,6 @@ void HazkeyEngine::activate([[maybe_unused]] const InputMethodEntry &entry,
     auto inputContext = event.inputContext();
     auto state = inputContext->propertyFor(&factory_);
     state->reset();
-    inputContext->updatePreedit();
     inputContext->updateUserInterface(UserInterfaceComponent::InputPanel);
 }
 
@@ -44,9 +57,14 @@ void HazkeyEngine::deactivate([[maybe_unused]] const InputMethodEntry &entry,
     FCITX_DEBUG() << "HazkeyEngine deactivate";
     auto inputContext = event.inputContext();
     auto state = inputContext->propertyFor(&factory_);
-    state->commitPreedit();
+    bool hadVisiblePreedit = hasVisiblePreedit(inputContext);
+    if (hadVisiblePreedit) {
+        state->commitPreedit();
+    }
     state->reset();
-    inputContext->updatePreedit();
+    if (hadVisiblePreedit) {
+        inputContext->updatePreedit();
+    }
     inputContext->updateUserInterface(UserInterfaceComponent::InputPanel);
 }
 


### PR DESCRIPTION
## 概要

Hazkey が未入力状態のときに、空の preedit update をアプリケーションへ送らないようにします。

具体的には以下を変更しています。

- キーイベント後の `updatePreedit()` は、Hazkey がイベントを受理した場合のみ呼ぶ
- activate 時の `reset()` 後に `updatePreedit()` を呼ばない
- deactivate 時は、表示中の preedit がある場合のみ commit / clear する

## 背景

一部の Electron / Web ベースの入力欄では、IME から空の client preedit update が送られたときに、それが「未確定文字列の表示を消す」だけでなく、フォーカス中の入力内容を空文字で置き換えるように扱われる場合があります。

変更前の `HazkeyEngine` は、`activate()`、`keyEvent()`、`deactivate()` で `updatePreedit()` を無条件に呼んでいました。

そのため、Hazkey 側にアプリへ反映すべき未確定文字列がない状態でも、空の preedit 状態をアプリへ通知していました。

実際に以下のケースで、既存の入力内容が消えることを確認しました。

- Google Tasks のタスク入力欄に、Hazkey が有効な状態でフォーカスを移したとき
- Typora で Hazkey が未入力状態のときに Ctrl+A を押したとき


## 対応

Hazkey が実際に preedit 状態をアプリケーションへ同期する必要がある場合だけ `updatePreedit()` を呼ぶようにしました。

これにより、未入力状態での IM 切り替えやフォーカス時に、アプリケーションへ不要な空 preedit が送られないようになります。
